### PR TITLE
[SWE-1591] - bump actionlint version

### DIFF
--- a/.github/workflows/workflow_ci.yml
+++ b/.github/workflows/workflow_ci.yml
@@ -22,7 +22,7 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
     container:
-      image: rhysd/actionlint:1.6.8
+      image: rhysd/actionlint:1.6.12
       options: --user root
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Bump `actionlint` version.

https://vergesense.atlassian.net/browse/SWE-1591

